### PR TITLE
Add message sub-type example

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -99,21 +99,14 @@ The `Message` sub-type is designed to be used by a 7683 user to incentivize a fi
 
 ```solidity
 function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
-	// Input[] userInputs;
-	// Output[] maxOutputs;
-	// Output[] minFillerOutputs;
 	(
 		address user,
-		uint32 originChainId,
-		uint32 initiateDeadline,
 		uint32 fillDeadline,
-		Input[] memory userInputs,
-		Output[] memory maxOutputs,
- 		Output[] memory minFillerOutputs,
+		Output memory fillerOutput,
 		Message memory message
 	) = abi.decode(originData);
 
-	// ...Do some preprocessing on the parameters here to validate a ResolvedCrossChainOrder...
+	// ...Do some preprocessing on the parameters here to validate the order...
 
 	// ...Execute the fill logic of the ResolvedCrossChainOrder...
 

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -316,6 +316,8 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
     }
 ```
 
+In this example, the Message sub-type allows the user to delegate destination chain contract execution to fillers. However, because transactions are executed via filler, the `msg.sender` would be equal to the filler's account, making this `Message` sub-type limited if the target contract authenticates based on the `msg.sender`. Ideally, 7683 orders containing Messages can be combined with smart contract wallets like implementations of [ERC4337](https://github.com/across-protocol/ERCs/blob/master/ERCS/erc-4337.md) or [EIP7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) to allow complete cross-chain delegated execution.
+
 ### Cross-compatibility
 
 Since this standard is intended to reduce friction for users moving value across chains, non-EVM ecosystems should not be excluded. However, attempting

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -70,98 +70,11 @@ struct OnchainCrossChainOrder {
 
 Cross-chain execution systems implementing this standard SHOULD use a sub-type that can be parsed from the arbitrary `orderData` field. This may include information such as the tokens involved in the transfer, the destination chain IDs, fulfillment constraints or settlement oracles.
 
-All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to encourage sharing of sub-types based on their functionality.
-
-### Decoding cross-chain orders
-
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution. It is the responsibility of the `user` and the `filler` to ensure that the `settlementContract` supports their order's contained sub-type. For example, there might be a sub-type called `Message`, which is defined by the following structs:
-
-```solidity
-// The Message subtype allows ERC7683 intents to carry calldata that is executed on a target contract on the destination chain. The settlement contract that the filler interacts with on the destination chain will decode the message into smart contract calls and execute the calls within the filler's `fill()` transaction.
-
-// The Message contains calls that the user wants executed on the destination chain.
-// The target is a contract on the destination chain that the settlement contract will attempt to send callData and value to.
-struct Calls {
-  address target;
-  bytes callData;
-  uint256 value;
-}
-
-// A fallbackRecipient can be set by the user in case sending the callData to the target reverts and the user still wants to guarantee that they receive their value to an EOA
-// on the destination chain.
-struct Message {
-  Calls[] calls;
-  address fallbackRecipient;
-}
-```
-
-The `Message` sub-type is designed to be used by a 7683 user to incentivize a filler to to execute arbitrary calldata on a target destination chain contracton the user's behalf. For example, the settlement contract might decode the `orderData` containing the message information as follows:
-
-```solidity
-function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
-	(
-		address user,
-		uint32 fillDeadline,
-		Output memory fillerOutput,
-		Message memory message
-	) = abi.decode(originData);
-
-	// ...Do some preprocessing on the parameters here to validate the order...
-
-	// ...Execute the fill logic of the ResolvedCrossChainOrder...
-
-	// Handle the Message subtype:
-
-        // If there is no fallback recipient, call and revert if the inner call fails.
-        if (message.fallbackRecipient == address(0)) {
-            this.attemptCalls(message.calls);
-            return;
-        }
-
-        // Otherwise, try the call and send to the fallback recipient if any tokens are leftover.
-        (bool success, ) = address(this).call(abi.encodeCall(this.attemptCalls, (message.calls)));
-        if (!success) emit CallsFailed(message.calls, message.fallbackRecipient);
-
-        // If there are leftover tokens, send them to the fallback recipient regardless of execution success.
-        _drainRemainingTokens(token, payable(message.fallbackRecipient));
-    }
-
-    function attemptCalls(Call[] memory calls) external onlySelf {
-        uint256 length = calls.length;
-        for (uint256 i = 0; i < length; ++i) {
-            Call memory call = calls[i];
-
-            // If we are calling an EOA with calldata, assume target was incorrectly specified and revert.
-            if (call.callData.length > 0 && call.target.code.length == 0) {
-                revert InvalidCall(i, calls);
-            }
-
-            (bool success, ) = call.target.call{ value: call.value }(call.callData);
-            if (!success) revert CallReverted(i, calls);
-        }
-    }
-
-    function _drainRemainingTokens(address token, address payable destination) internal {
-        if (token != address(0)) {
-            // ERC20 token.
-            uint256 amount = IERC20(token).balanceOf(address(this));
-            if (amount > 0) {
-                IERC20(token).safeTransfer(destination, amount);
-                emit DrainedTokens(destination, token, amount);
-            }
-        } else {
-            // Send native token
-            uint256 amount = address(this).balance;
-            if (amount > 0) {
-                destination.sendValue(amount);
-            }
-        }
-    }
-```
+All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to encourage sharing of sub-types based on their functionality. See the examples section for an example of how sub-types can be used to support behavior like executing calldata on a target contract of the user's choice on the destination chain.
 
 ### ResolvedCrossChainOrder struct
 
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct.
+A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution (see the examples section for an example of this). It is the responsibility of the `user` and the `filler` to ensure that the `settlementContract` supports their order's contained sub-type.
 
 ```solidity
 /// @title ResolvedCrossChainOrder type
@@ -343,6 +256,65 @@ additional implementation costs on fillers.
 
 This functionality also makes it feasible for a user, filler, or order distribution system to perform an end-to-end simulation of the order initiation
 and fill to evaluate all resulting state transitions without understanding the nuances of a particular execution system.
+
+## Examples
+
+This is an example of how a 7683 cross-chain value transfer order can include instructions to the filler to execute arbitrary calldata on behalf of the recipient on the destination chain. This calldata execution is performed by the settlement contract atomically within the filler's fill() execution, so the arbitrary contract execution can take advantage of the destination chain recipient's newly transferred value. A hypothetical user in this example would select a `settlementContract` that is known to support the `Message` sub-type.
+
+Let there be a sub-type called `Message`, which is defined by the following structs:
+
+```solidity
+// The Message subtype allows ERC7683 intents to carry calldata that is executed on a target contract on the destination chain. The settlement contract that the filler interacts with on the destination chain will decode the message into smart contract calls and execute the calls within the filler's `fill()` transaction.
+
+// The Message contains calls that the user wants executed on the destination chain.
+// The target is a contract on the destination chain that the settlement contract will attempt to send callData and value to.
+struct Calls {
+  address target;
+  bytes callData;
+  uint256 value;
+}
+
+struct Message {
+  Calls[] calls;
+}
+```
+
+The `Message` sub-type is designed to be used by a 7683 user to incentivize a filler to to execute arbitrary calldata on a target destination chain contracton the user's behalf. For example, the settlement contract might decode the `orderData` containing the message information as follows:
+
+```solidity
+function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
+	(
+		address user,
+		uint32 fillDeadline,
+		Output memory fillerOutput,
+		Message memory message
+	) = abi.decode(originData);
+
+	// ...Do some preprocessing on the parameters here to validate the order...
+
+	// ...Execute the fill logic of the ResolvedCrossChainOrder...
+
+	// Handle the Message subtype:
+
+        // Revert if any of the message calls fail.
+	this.attemptCalls(message.calls);
+    }
+
+    function attemptCalls(Call[] memory calls) external onlySelf {
+        uint256 length = calls.length;
+        for (uint256 i = 0; i < length; ++i) {
+            Call memory call = calls[i];
+
+            // If we are calling an EOA with calldata, assume target was incorrectly specified and revert.
+            if (call.callData.length > 0 && call.target.code.length == 0) {
+                revert InvalidCall(i, calls);
+            }
+
+            (bool success, ) = call.target.call{ value: call.value }(call.callData);
+            if (!success) revert CallReverted(i, calls);
+        }
+    }
+```
 
 ### Cross-compatibility
 

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -74,7 +74,7 @@ All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to enco
 
 ### Decoding cross-chain orders
 
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that are used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain calldata execution. It is the responsibility of the `user` and the `filler` to ensure that the `settlementContract` supports their order's contained sub-type. For example, there might be a sub-type called `Message`, which is defined by the following structs:
+A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into the information needed to populate the `ResolvedCrossChainOrder` struct. Additionally, `orderData` SHOULD be decodable into a sub-type, which can be used for further functionality such as cross-chain calldata execution. It is the responsibility of the `user` and the `filler` to ensure that the `settlementContract` supports their order's contained sub-type. For example, there might be a sub-type called `Message`, which is defined by the following structs:
 
 ```solidity
 // The Message subtype allows ERC7683 intents to carry calldata that is executed on a target contract on the destination chain. The settlement contract that the filler interacts with on the destination chain will decode the message into smart contract calls and execute the calls within the filler's `fill()` transaction.

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -110,7 +110,7 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
 		Input[] memory userInputs,
 		Output[] memory maxOutputs,
  		Output[] memory minFillerOutputs,
-		Instructions memory instructions
+		Message memory message
 	) = abi.decode(originData);
 
 	// ...Do some preprocessing on the parameters here to validate a ResolvedCrossChainOrder...
@@ -120,17 +120,17 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
 	// Handle the Message subtype:
 
         // If there is no fallback recipient, call and revert if the inner call fails.
-        if (instructions.fallbackRecipient == address(0)) {
-            this.attemptCalls(instructions.calls);
+        if (message.fallbackRecipient == address(0)) {
+            this.attemptCalls(message.calls);
             return;
         }
 
         // Otherwise, try the call and send to the fallback recipient if any tokens are leftover.
-        (bool success, ) = address(this).call(abi.encodeCall(this.attemptCalls, (instructions.calls)));
-        if (!success) emit CallsFailed(instructions.calls, instructions.fallbackRecipient);
+        (bool success, ) = address(this).call(abi.encodeCall(this.attemptCalls, (message.calls)));
+        if (!success) emit CallsFailed(message.calls, message.fallbackRecipient);
 
         // If there are leftover tokens, send them to the fallback recipient regardless of execution success.
-        _drainRemainingTokens(token, payable(instructions.fallbackRecipient));
+        _drainRemainingTokens(token, payable(message.fallbackRecipient));
     }
 
     function attemptCalls(Call[] memory calls) external onlySelf {

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -74,43 +74,96 @@ All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to enco
 
 ### Decoding cross-chain orders
 
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that are used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain calldata execution. For example, there might be a sub-type called `Message`:
-
-```
-Message
-
-The Message subtype allows ERC7683 intents to carry messages that are executed on the destination chain.
-
-Struct MessageInfo {
-  bytes message;
-  address fallbackTarget;
-}
-
-Sub-type selector: "Message"
-
-The intent recipient will receive the tokens, then the message will be called. If the fallbackTarget is set, then, in the case of revert, the tokens will be sent to the fallbackTarget. If not set, reverts will cause the entire transaction to fail and the intent will be impossible to fulfill.
-
-To use this extension, abi.encode the Message function (pre-pending the selector). Then include those bytes in the list of sub-types in the ERC 7683 orderData.
-```
-
-Then, the `orderData` could be decoded as follows within a `settlementContract`'s fill function:
+A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that are used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain calldata execution. It is the responsibility of the `user` and the `filler` to ensure that the `settlementContract` supports their order's contained sub-type. For example, there might be a sub-type called `Message`, which is defined by the following structs:
 
 ```solidity
+// The Message subtype allows ERC7683 intents to carry calldata that is executed on a target contract on the destination chain. The settlement contract that the filler interacts with on the destination chain will decode the message into smart contract calls and execute the calls within the filler's `fill()` transaction.
 
-// Let's assume we have the original 7683 order's orderData:
-bytes memory orderData;
+// The Message contains calls that the user wants executed on the destination chain.
+// The target is a contract on the destination chain that the settlement contract will attempt to send callData and value to.
+struct Calls {
+  address target;
+  bytes callData;
+  uint256 value;
+}
 
-(ResolvedCrossChainOrder memory resolvedCrossChainOrder, bytes[] subtypes) = abi.decode(orderData)
+// A fallbackRecipient can be set by the user in case sending the callData to the target reverts and the user still wants to guarantee that they receive their value to an EOA
+// on the destination chain.
+struct Message {
+  Calls[] calls;
+  address fallbackRecipient;
+}
+```
 
+The `Message` sub-type is designed to be used by a 7683 user to incentivize a filler to to execute arbitrary calldata on a target destination chain contracton the user's behalf. For example, the settlement contract might decode the `orderData` containing the message information as follows:
 
-// Imagine this settlementContract only expects a single, Message, sub-type
-require(subtypes.length == 1);
-(bytes4 subtypeSelector, bytes messageInfo) = abi.decode(subtypes[0]);
-require(subtypeSelector == bytes4(keccak256("Message")));
-(bytes message, address fallbackTarget) = abi.decode(messageInfo);
+```solidity
+function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) public {
+	// Input[] userInputs;
+	// Output[] maxOutputs;
+	// Output[] minFillerOutputs;
+	(
+		address user,
+		uint32 originChainId,
+		uint32 initiateDeadline,
+		uint32 fillDeadline,
+		Input[] memory userInputs,
+		Output[] memory maxOutputs,
+ 		Output[] memory minFillerOutputs,
+		Instructions memory instructions
+	) = abi.decode(originData);
 
-// Do stuff with the message...
+	// ...Do some preprocessing on the parameters here to validate a ResolvedCrossChainOrder...
 
+	// ...Execute the fill logic of the ResolvedCrossChainOrder...
+
+	// Handle the Message subtype:
+
+        // If there is no fallback recipient, call and revert if the inner call fails.
+        if (instructions.fallbackRecipient == address(0)) {
+            this.attemptCalls(instructions.calls);
+            return;
+        }
+
+        // Otherwise, try the call and send to the fallback recipient if any tokens are leftover.
+        (bool success, ) = address(this).call(abi.encodeCall(this.attemptCalls, (instructions.calls)));
+        if (!success) emit CallsFailed(instructions.calls, instructions.fallbackRecipient);
+
+        // If there are leftover tokens, send them to the fallback recipient regardless of execution success.
+        _drainRemainingTokens(token, payable(instructions.fallbackRecipient));
+    }
+
+    function attemptCalls(Call[] memory calls) external onlySelf {
+        uint256 length = calls.length;
+        for (uint256 i = 0; i < length; ++i) {
+            Call memory call = calls[i];
+
+            // If we are calling an EOA with calldata, assume target was incorrectly specified and revert.
+            if (call.callData.length > 0 && call.target.code.length == 0) {
+                revert InvalidCall(i, calls);
+            }
+
+            (bool success, ) = call.target.call{ value: call.value }(call.callData);
+            if (!success) revert CallReverted(i, calls);
+        }
+    }
+
+    function _drainRemainingTokens(address token, address payable destination) internal {
+        if (token != address(0)) {
+            // ERC20 token.
+            uint256 amount = IERC20(token).balanceOf(address(this));
+            if (amount > 0) {
+                IERC20(token).safeTransfer(destination, amount);
+                emit DrainedTokens(destination, token, amount);
+            }
+        } else {
+            // Send native token
+            uint256 amount = address(this).balance;
+            if (amount > 0) {
+                destination.sendValue(amount);
+            }
+        }
+    }
 ```
 
 ### ResolvedCrossChainOrder struct

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -74,14 +74,12 @@ All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to enco
 
 ### Decoding cross-chain orders
 
-A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that could be used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain transaction execution. For example, there might be a sub-type called `Message`:
+A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that are used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain calldata execution. For example, there might be a sub-type called `Message`:
 
 ```
 Message
 
 The Message subtype allows ERC7683 intents to carry messages that are executed on the destination chain.
-
-To use the message subtype, abi encode the following:
 
 Struct MessageInfo {
   bytes message;

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -72,6 +72,49 @@ Cross-chain execution systems implementing this standard SHOULD use a sub-type t
 
 All sub-types SHOULD be registered at github.com/erc-7683/order-subtypes to encourage sharing of sub-types based on their functionality.
 
+### Decoding cross-chain orders
+
+A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct. This means that the `orderData` must be decoded into parameters that could be used to populate the `ResolvedCrossChainOrder` struct. The decoded `orderData` SHOULD also contain data to construct a sub-type, which can be used for further functionality such as cross-chain transaction execution. For example, there might be a sub-type called `Message`:
+
+```
+Message
+
+The Message subtype allows ERC7683 intents to carry messages that are executed on the destination chain.
+
+To use the message subtype, abi encode the following:
+
+Struct MessageInfo {
+  bytes message;
+  address fallbackTarget;
+}
+
+Sub-type selector: "Message"
+
+The intent recipient will receive the tokens, then the message will be called. If the fallbackTarget is set, then, in the case of revert, the tokens will be sent to the fallbackTarget. If not set, reverts will cause the entire transaction to fail and the intent will be impossible to fulfill.
+
+To use this extension, abi.encode the Message function (pre-pending the selector). Then include those bytes in the list of sub-types in the ERC 7683 orderData.
+```
+
+Then, the `orderData` could be decoded as follows within a `settlementContract`'s fill function:
+
+```solidity
+
+// Let's assume we have the original 7683 order's orderData:
+bytes memory orderData;
+
+(ResolvedCrossChainOrder memory resolvedCrossChainOrder, bytes[] subtypes) = abi.decode(orderData)
+
+
+// Imagine this settlementContract only expects a single, Message, sub-type
+require(subtypes.length == 1);
+(bytes4 subtypeSelector, bytes messageInfo) = abi.decode(subtypes[0]);
+require(subtypeSelector == bytes4(keccak256("Message")));
+(bytes message, address fallbackTarget) = abi.decode(messageInfo);
+
+// Do stuff with the message...
+
+```
+
 ### ResolvedCrossChainOrder struct
 
 A compliant cross-chain order type MUST be convertible into the `ResolvedCrossChainOrder` struct.

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -297,13 +297,9 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
 	// Handle the Message subtype:
 
         // Revert if any of the message calls fail.
-	this.attemptCalls(message.calls);
-    }
-
-    function attemptCalls(Call[] memory calls) external onlySelf {
-        uint256 length = calls.length;
+        uint256 length = message.calls.length;
         for (uint256 i = 0; i < length; ++i) {
-            Call memory call = calls[i];
+            Call memory call = message.calls[i];
 
             // If we are calling an EOA with calldata, assume target was incorrectly specified and revert.
             if (call.callData.length > 0 && call.target.code.length == 0) {
@@ -311,7 +307,7 @@ function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerD
             }
 
             (bool success, ) = call.target.call{ value: call.value }(call.callData);
-            if (!success) revert CallReverted(i, calls);
+            if (!success) revert CallReverted(i, message.calls);
         }
     }
 ```


### PR DESCRIPTION
Make it more clear how 7683 can support cross chain (arbitrary calldata) requests combined with value transfer