### PR TITLE
Add section about evaluating a settlementContract's security

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -204,6 +204,12 @@ Cross-chain execution systems implementing this standard SHOULD use a sub-type t
 
 All sub-types SHOULD be registered at github.com/erc-7683/filler-data-subtypes to encourage sharing of sub-types based on their functionality.
 
+#### Evaluating settlement contract security
+
+This ERC is agnostic of how the `settlementContract` validates a 7683 order fulfillment and refunds the filler. In fact, this ERC is designed to delegate the responsibility of evaluating the settlement contract's security to the filler and the application that creates the user's 7683 order.
+
+This design decision is motivated by the existence of many viable cross-chain messaging systems today offering settlement contracts a variety of tradeoffs. We hope that ERC7683 can eventually support an ERC dedicated to standardizing a safe, cross-chain messaging layer.
+
 ### fillerData
 
 ## Rationale

--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -208,7 +208,7 @@ All sub-types SHOULD be registered at github.com/erc-7683/filler-data-subtypes t
 
 This ERC is agnostic of how the `settlementContract` validates a 7683 order fulfillment and refunds the filler. In fact, this ERC is designed to delegate the responsibility of evaluating the settlement contract's security to the filler and the application that creates the user's 7683 order.
 
-This design decision is motivated by the existence of many viable cross-chain messaging systems today offering settlement contracts a variety of tradeoffs. We hope that ERC7683 can eventually support an ERC dedicated to standardizing a safe, cross-chain messaging layer.
+This design decision is motivated by the existence of many viable cross-chain messaging systems today offering settlement contracts a variety of tradeoffs. We hope that ERC7683 can eventually support an ERC dedicated to standardizing a safe, trustless, cross-chain verification system.
 
 ### fillerData
 


### PR DESCRIPTION
We've received enough feedback that its worth mentioning explicitly the reason for this ERC being proof-agnostic.

Perhaps this section is where we can add @wilsoncusack 's work on [RIP7755/Cross-Chain-L2-Call-Standard](https://github.com/wilsoncusack/RIPs/blob/cross-l2-call-standard/RIPS/rip-7755.md)