### PR TITLE
Add clause about not knowing `minOutput.recipient` at order creation time

### DIFF
--- a/ERCS/erc-7683.md
+++ b/ERCS/erc-7683.md
@@ -108,7 +108,8 @@ struct ResolvedCrossChainOrder {
 	Output[] maxSpent;
 	/// @dev The minimum outputs that must be given to the filler as part of order settlement. Similar to maxSpent, it's possible
 	///      that special order types may not be able to guarantee the exact amount at open time, so this should be considered
-	///      a floor on filler receipts.
+	///      a floor on filler receipts. Setting the `recipient` of an `Output` to address(0) indicates that the filler is not
+        ///      known when creating this order.
 	Output[] minReceived;
 	/// @dev Each instruction in this array is parameterizes a single leg of the fill. This provides the filler with the information
 	///      necessary to perform the fill on the destination(s).


### PR DESCRIPTION
## Motivation

Its not always known who the recipient of a `minOutput` will be, especially when creating an `OnchainCrossChainOrder` where the user submits their own order and the `originData` does not contain any reference to an exclusive relayer.

Moreover, even in a `GaslessCrossChainOrder`, the filler creating the deposit on the origin chain might not always fill their own order on the destination chain if they do not set themselves as an exclusive relayer.

Not all settlement contracts will allow an order to specify an exclusivity clause.

## Solution

Explicitly state setting `recipient: address(0)` as an option when creating the `minOutputs`.